### PR TITLE
Handle pdf2image dependency errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Le script `test_api.py` effectue :
 - ✅ Tests de performance
 - ✅ Validation de l'API complète
 
+### Gestion des dépendances PDF
+
+- ⚠️ Un PDF valide envoyé sans dépendances système (ex: **Poppler** manquant) renvoie désormais une erreur serveur explicite `503` indiquant un problème de conversion côté serveur.
+
 ## 📝 Changements Techniques
 
 ### Avant (Bugs)

--- a/tests/test_pdf_conversion.py
+++ b/tests/test_pdf_conversion.py
@@ -1,0 +1,72 @@
+import importlib
+import io
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from pdf2image.exceptions import PDFInfoNotInstalledError
+from PIL import Image
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+class _DummyPaddleOCR:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    monkeypatch = pytest.MonkeyPatch()
+    fake_paddleocr = types.ModuleType("paddleocr")
+    fake_paddleocr.PaddleOCR = _DummyPaddleOCR
+    fake_paddleocr.__version__ = "test"
+    monkeypatch.setitem(sys.modules, "paddleocr", fake_paddleocr)
+
+    module = importlib.import_module("app")
+
+    yield module
+
+    monkeypatch.undo()
+    sys.modules.pop("app", None)
+
+
+def create_png_bytes() -> bytes:
+    image = Image.new("RGB", (10, 10), color="white")
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_pdf_conversion_missing_dependencies(app_module, monkeypatch):
+    def fake_convert_from_bytes(*args, **kwargs):
+        raise PDFInfoNotInstalledError("Poppler not installed")
+
+    monkeypatch.setattr(app_module, "convert_from_bytes", fake_convert_from_bytes)
+
+    pdf_bytes = b"%PDF-1.4 test"
+
+    with pytest.raises(HTTPException) as exc_info:
+        app_module.convert_bytes_to_images(pdf_bytes)
+
+    assert exc_info.value.status_code == 503
+    assert "Conversion PDF impossible" in exc_info.value.detail
+
+
+def test_pdf_conversion_fallback_to_image(app_module, monkeypatch):
+    def fake_convert_from_bytes(*args, **kwargs):
+        raise ValueError("generic pdf error")
+
+    monkeypatch.setattr(app_module, "convert_from_bytes", fake_convert_from_bytes)
+
+    png_bytes = create_png_bytes()
+
+    images = app_module.convert_bytes_to_images(png_bytes)
+
+    assert len(images) == 1
+    assert isinstance(images[0], Image.Image)


### PR DESCRIPTION
## Summary
- surface pdf2image dependency failures as 503 errors instead of falling back to image handling
- retain the image fallback for non-PDF documents while documenting the new behaviour
- add targeted tests that stub paddleocr to validate the new error path and image fallback

## Testing
- pytest tests/test_pdf_conversion.py

------
https://chatgpt.com/codex/tasks/task_e_68d453053d48832ca0560477f31f489f

## Summary by Sourcery

Surface critical PDF conversion failures due to missing pdf2image dependencies as HTTP 503, retain direct image fallback for non-PDF inputs, update documentation, and add tests for both error and fallback paths.

Enhancements:
- Raise HTTP 503 on pdf2image dependency errors during PDF conversion while preserving fallback to direct image handling for other inputs

Documentation:
- Document the new 503 error response for missing PDF dependencies in the README under PDF dependency handling

Tests:
- Add a test that stubs pdf2image to simulate missing dependencies and expects an HTTP 503 error
- Add a test that simulates a generic PDF error and verifies the fallback to direct image conversion