### PR TITLE
Improve file validation MIME detection

### DIFF
--- a/tests/test_pdf_conversion.py
+++ b/tests/test_pdf_conversion.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 from pdf2image.exceptions import PDFInfoNotInstalledError
 from PIL import Image
+from starlette.datastructures import Headers, UploadFile
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -70,3 +71,14 @@ def test_pdf_conversion_fallback_to_image(app_module, monkeypatch):
 
     assert len(images) == 1
     assert isinstance(images[0], Image.Image)
+
+
+def test_validate_file_accepts_pdf_without_extension(app_module):
+    pdf_bytes = b"%PDF-1.4 minimal"
+    headers = Headers({"content-type": "application/pdf"})
+    upload = UploadFile(filename="document", file=io.BytesIO(pdf_bytes), headers=headers)
+
+    try:
+        app_module.validate_file(upload, pdf_bytes)
+    except HTTPException as exc:
+        pytest.fail(f"validate_file should accept valid PDF without extension: {exc}")


### PR DESCRIPTION
## Summary
- broaden file validation to inspect multiple MIME sources, including request metadata and binary signatures
- ensure PDF uploads without extensions are accepted and add regression coverage

## Testing
- pytest *(fails: local API server not running for integration tests)*
- pytest tests/test_pdf_conversion.py


------
https://chatgpt.com/codex/tasks/task_e_68d45b245ffc832c82074cfc85dfd1b0

## Summary by Sourcery

Enhance file validation to use multiple MIME sources and binary signatures and ensure PDFs without extensions are accepted

New Features:
- Extend validation to consider filename guess, content-type header, PDF magic bytes, and image signatures via imghdr
- Accept PDF uploads that lack file extensions

Tests:
- Add regression test to verify that validate_file accepts PDF files without extensions